### PR TITLE
Fix pixi PATH in setup_mac.sh ($HOME, not literal /HOME)

### DIFF
--- a/env/setup_mac.sh
+++ b/env/setup_mac.sh
@@ -3,7 +3,7 @@
 
 # install pixi
 curl -fsSL https://pixi.sh/install.sh | sh
-export PATH="/HOME/.pixi/bin:$PATH"
+export PATH="$HOME/.pixi/bin:$PATH"
 
 # create environment
 # use the default pixi environment if PIXI_ENV is not set


### PR DESCRIPTION
`env/setup_mac.sh` exports a literal `/HOME/.pixi/bin` instead of `$HOME`:

  ```diff
  -export PATH="/HOME/.pixi/bin:$PATH"
  +export PATH="$HOME/.pixi/bin:$PATH"
```

  pixi installs to $HOME/.pixi/bin, so with the literal /HOME, pixi isn't on
  PATH and the next steps (pixi install, pixi run post-install) fail.

  It slips by on macOS because the filesystem is case-insensitive: /HOME
  resolves to /home (an empty autofs mount) instead of erroring. $HOME is
  correct on both macOS and Linux. (The Linux setup.sh is fine — it uses
  /root/.pixi/bin.)